### PR TITLE
Allow Workflow to Proceed Even if Linting Fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
         continue-on-error: true
 
       - name: Run Tests
+        env:
+        SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: |
           python manage.py migrate
           python manage.py test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,20 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Dependencies
         run: pip install -r requirements.txt black
 
       - name: Run Lint
         run: black --check .
+        continue-on-error: true
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
This PR updates the CI/CD pipeline to allow the workflow to continue even if the linting step fails. The changes include:

#### 1. **Allow Linting to Fail Without Stopping the Workflow**:
- The linting step (`black --check .`) will now run without blocking the pipeline if it fails, ensuring subsequent steps (like testing and deployment) proceed as planned.

#### 2. **Updated `Lint and Test` Job**:
- The `continue-on-error: true` attribute has been added to the linting step to allow the pipeline to proceed, even in case of linting errors.
